### PR TITLE
修复可移动元素涟漪错位

### DIFF
--- a/src/ripple.vue
+++ b/src/ripple.vue
@@ -144,7 +144,7 @@
         if (this.handleMouseDown(event) === false) {
           return
         }
-        let boundingRect = this._boundingRect
+        let boundingRect = this.$el.getBoundingClientRect()
 
         // mousedown or touchstart x, y
         let downX = event.touches ? event.touches[0].pageX : event.clientX


### PR DESCRIPTION
将组件用在列表里, 滑动列表后涟漪会偏移到右边
